### PR TITLE
[TASK] allow installation of TYPO3 v13.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "typo3/cms-core": "^12.4"
+        "typo3/cms-core": "^12.4 || ^13.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Since no deprecated TYPO3 APIs are used in this extension, it can be safely considered compatible with TYPO3 13.

Output of unit tests:
```
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.24

....................                                              20 / 20 (100%)

Time: 00:00.006, Memory: 4.00 MB

OK (20 tests, 20 assertions)`
```
